### PR TITLE
Fix xdebug version to 2.9.8

### DIFF
--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -43,7 +43,11 @@ class Pecl extends AbstractPecl
      */
     const EXTENSIONS = [
         self::XDEBUG_EXTENSION => [
-            '7.0' => '2.9.0',
+            '7.4' => '2.9.8',
+            '7.3' => '2.9.8',
+            '7.2' => '2.9.8',
+            '7.1' => '2.9.8',
+            '7.0' => '2.9.8',
             '5.6' => '2.2.7',
             'default' => false,
             'extension_type' => self::ZEND_EXTENSION_TYPE


### PR DESCRIPTION
xdebug 3 now stable but has various compatibility issue with Valet config and Magento

Restricting to 2.9.8 prevents this

- [ ] There is an issue ticket which accompanies my PR: <Your-Issue-Link>.
- [ ] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [ ] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [ ] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Because this is a Bug Fix which is Backwards Compatible.  
Because this is a Feature which is not Backwards Compatible.  
Because this is a Deprecation which is Backwards Compatible.  
etc...

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).
